### PR TITLE
fix: allow for arm64 images

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -32,7 +32,6 @@ services:
       - scripts/pressbooks_required_libraries.sh
     build:
       - composer install
-      - cd web/app/plugins/pressbooks-network-catalog && composer install
   mailhog:
     hogfrom:
       - appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -15,7 +15,7 @@ env_file:
   - config_services/.env
 services:
   database:
-    type: mariadb:10.5
+    type: mariadb:10.5.23
     portforward: 32777
   redis:
     type: redis:5.0
@@ -37,6 +37,8 @@ services:
     hogfrom:
       - appserver
     type: mailhog
+    overrides:
+      image: anatomicjc/mailhog:1.0.1
     portforward: 8025
 tooling:
   php:


### PR DESCRIPTION
I was getting amd64 images for mariadb and for mailhog. Being more specific for the mariadb version seems to get the right arch. Apparently mailhog is getting stale, so users are pulling from a different source.

https://github.com/lando/mailhog/issues/22