### PR TITLE
feat: add wp-cli.yml to facility WP CLI usage

### DIFF
--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,3 @@
+path: web/wp
+server:
+  docroot: web


### PR DESCRIPTION
If I run `lando wp plugin list` (for example) I get the following error:

```
Error: This does not seem to be a WordPress installation.
The used path is: /app/
Pass --path=`path/to/wordpress` or run `wp core download`.
```

Adding this  WP CLI config file lets one run `lando wp` without issues from the root of the project.