### PR TITLE
fix: ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-.composer.lock
+composer.lock
 /log/nginx-stable
 /log/php-fpm-*
 .idea/


### PR DESCRIPTION
In #8, `composer.lock` was removed but the `.gitignore` file was not properly updated.