### PR TITLE
chore: require php 8.2

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -23,7 +23,7 @@ services:
   node:
     type: node
   appserver:
-    type: php:8.1
+    type: php:8.2
     xdebug: true
     environment:
       PHP_IDE_CONFIG: "serverName=appserver"


### PR DESCRIPTION
Pressbooks requires PHP 8.2 now so this needs to be updated.